### PR TITLE
Fix macro naming

### DIFF
--- a/lis2dw12_STdC/driver/lis2dw12_reg.h
+++ b/lis2dw12_STdC/driver/lis2dw12_reg.h
@@ -140,10 +140,10 @@ typedef struct {
 #define LIS2DW12_FROM_FS_8g_TO_mg(lsb)   (float)((int16_t)lsb >> 2) * 0.976f
 #define LIS2DW12_FROM_FS_16g_TO_mg(lsb)  (float)((int16_t)lsb >> 2) * 1.952f
 
-#define LIS2DH12_FROM_FS_2g_LP1_TO_mg(lsb)  (float)((int16_t)lsb>>4)* 0.976.0f
-#define LIS2DH12_FROM_FS_4g_LP1_TO_mg(lsb)  (float)((int16_t)lsb>>4)* 1.952.0f
-#define LIS2DH12_FROM_FS_8g_LP1_TO_mg(lsb)  (float)((int16_t)lsb>>4)* 3.904f
-#define LIS2DH12_FROM_FS_16g_LP1_TO_mg(lsb) (float)((int16_t)lsb>>4)* 7.808f
+#define LIS2DW12_FROM_FS_2g_LP1_TO_mg(lsb)  (float)((int16_t)lsb>>4)* 0.976.0f
+#define LIS2DW12_FROM_FS_4g_LP1_TO_mg(lsb)  (float)((int16_t)lsb>>4)* 1.952.0f
+#define LIS2DW12_FROM_FS_8g_LP1_TO_mg(lsb)  (float)((int16_t)lsb>>4)* 3.904f
+#define LIS2DW12_FROM_FS_16g_LP1_TO_mg(lsb) (float)((int16_t)lsb>>4)* 7.808f
 
 #define LIS2DW12_FROM_LSB_TO_degC(lsb)    (float)((int16_t)lsb) / 16.0f+25.0f
 

--- a/lis2dw12_STdC/example/read_data_simple.c
+++ b/lis2dw12_STdC/example/read_data_simple.c
@@ -221,9 +221,9 @@ void example_main_lis2dw12(void)
       //acceleration_mg[1] = LIS2DW12_FROM_FS_8g_TO_mg( data_raw_acceleration.i16bit[1]);
       //acceleration_mg[2] = LIS2DW12_FROM_FS_8g_TO_mg( data_raw_acceleration.i16bit[2]);
  
-      acceleration_mg[0] = LIS2DH12_FROM_FS_8g_LP1_TO_mg( data_raw_acceleration.i16bit[0]);
-      acceleration_mg[1] = LIS2DH12_FROM_FS_8g_LP1_TO_mg( data_raw_acceleration.i16bit[1]);
-      acceleration_mg[2] = LIS2DH12_FROM_FS_8g_LP1_TO_mg( data_raw_acceleration.i16bit[2]);      
+      acceleration_mg[0] = LIS2DW12_FROM_FS_8g_LP1_TO_mg( data_raw_acceleration.i16bit[0]);
+      acceleration_mg[1] = LIS2DW12_FROM_FS_8g_LP1_TO_mg( data_raw_acceleration.i16bit[1]);
+      acceleration_mg[2] = LIS2DW12_FROM_FS_8g_LP1_TO_mg( data_raw_acceleration.i16bit[2]);      
       
       sprintf((char*)tx_buffer, "Acceleration [mg]:%4.2f\t%4.2f\t%4.2f\r\n",
               acceleration_mg[0], acceleration_mg[1], acceleration_mg[2]);


### PR DESCRIPTION
4 scaling macros were called `LIS2DH12` instead of `LIS2DW12`, fix those lines. 

Any license and assignment of copyright is ok for this contribution.