### PR TITLE
lis2ds12 (id20180831): fixed lis2ds12_fifo_data_level_get issue

### DIFF
--- a/lis2ds12_STdC/driver/lis2ds12_reg.c
+++ b/lis2ds12_STdC/driver/lis2ds12_reg.c
@@ -1970,7 +1970,7 @@ int32_t lis2ds12_fifo_data_level_get(lis2ds12_ctx_t *ctx, uint16_t *val)
   int32_t mm_error;
 
   mm_error = lis2ds12_read_reg(ctx, LIS2DS12_FIFO_SRC, &reg[0].byte, 2);
-  *val = (reg[1].fifo_src.diff << 7) + reg[0].byte;
+  *val = (reg[0].fifo_src.diff << 8) + reg[1].byte;
 
   return mm_error;
 }


### PR DESCRIPTION
Comment:
 - FIFO_SRC (2Fh) is read to reg[0]
 - FIFO_SAMPLES (30h) is read to reg[1]
 - DIFF8 need left shift 8bits to D8