### PR TITLE
changed lis2mdl_status_reg_t such that xor is not a variable name,

### DIFF
--- a/lis2mdl_STdC/driver/lis2mdl_reg.c
+++ b/lis2mdl_STdC/driver/lis2mdl_reg.c
@@ -597,7 +597,7 @@ int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_STATUS_REG, (uint8_t*)&reg, 1);
-  *val = reg.zyxor;
+  *val = reg.zyxovr;
 
   return ret;
 }

--- a/lis2mdl_STdC/driver/lis2mdl_reg.c
+++ b/lis2mdl_STdC/driver/lis2mdl_reg.c
@@ -597,7 +597,7 @@ int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_STATUS_REG, (uint8_t*)&reg, 1);
-  *val = reg.zyxovr;
+  *val = reg._zyxor;
 
   return ret;
 }

--- a/lis2mdl_STdC/driver/lis2mdl_reg.c
+++ b/lis2mdl_STdC/driver/lis2mdl_reg.c
@@ -597,7 +597,7 @@ int32_t lis2mdl_mag_data_ovr_get(lis2mdl_ctx_t *ctx, uint8_t *val)
   int32_t ret;
 
   ret = lis2mdl_read_reg(ctx, LIS2MDL_STATUS_REG, (uint8_t*)&reg, 1);
-  *val = reg._zyxor;
+  *val = reg.zyxor;
 
   return ret;
 }

--- a/lis2mdl_STdC/driver/lis2mdl_reg.h
+++ b/lis2mdl_STdC/driver/lis2mdl_reg.h
@@ -227,9 +227,9 @@ typedef struct {
   uint8_t zda                    : 1;
   uint8_t zyxda                  : 1;
   uint8_t _xor                    : 1;
-  uint8_t _yor                    : 1;
-  uint8_t _zor                    : 1;
-  uint8_t _zyxor                  : 1;
+  uint8_t yor                    : 1;
+  uint8_t zor                    : 1;
+  uint8_t zyxor                  : 1;
 } lis2mdl_status_reg_t;
 
 #define LIS2MDL_OUTX_L_REG              0x68U

--- a/lis2mdl_STdC/driver/lis2mdl_reg.h
+++ b/lis2mdl_STdC/driver/lis2mdl_reg.h
@@ -226,10 +226,10 @@ typedef struct {
   uint8_t yda                    : 1;
   uint8_t zda                    : 1;
   uint8_t zyxda                  : 1;
-  uint8_t xor                    : 1;
-  uint8_t yor                    : 1;
-  uint8_t zor                    : 1;
-  uint8_t zyxor                  : 1;
+  uint8_t xovr                    : 1;
+  uint8_t yovr                    : 1;
+  uint8_t zovr                    : 1;
+  uint8_t zyxovr                  : 1;
 } lis2mdl_status_reg_t;
 
 #define LIS2MDL_OUTX_L_REG              0x68U

--- a/lis2mdl_STdC/driver/lis2mdl_reg.h
+++ b/lis2mdl_STdC/driver/lis2mdl_reg.h
@@ -226,10 +226,10 @@ typedef struct {
   uint8_t yda                    : 1;
   uint8_t zda                    : 1;
   uint8_t zyxda                  : 1;
-  uint8_t xovr                    : 1;
-  uint8_t yovr                    : 1;
-  uint8_t zovr                    : 1;
-  uint8_t zyxovr                  : 1;
+  uint8_t _xor                    : 1;
+  uint8_t _yor                    : 1;
+  uint8_t _zor                    : 1;
+  uint8_t _zyxor                  : 1;
 } lis2mdl_status_reg_t;
 
 #define LIS2MDL_OUTX_L_REG              0x68U


### PR DESCRIPTION
This PR attempts to address [issue 19](https://github.com/STMicroelectronics/STMems_Standard_C_drivers/issues/19) I just submitted in which the lis2mdl C driver contains a variable which conflicts with a C++ keyword. A simple renaming of the variables in the header and implementation files should fix the issue.