### PR TITLE
lsm6dso: Fix wrong sensitivity values for gyroscope

### DIFF
--- a/lsm6dso_STdC/driver/lsm6dso_reg.h
+++ b/lsm6dso_STdC/driver/lsm6dso_reg.h
@@ -187,11 +187,11 @@ typedef struct {
 #define LSM6DSO_FROM_FS_8g_TO_mg(lsb)    (float)(lsb * 244.0f) / 1000.0f
 #define LSM6DSO_FROM_FS_16g_TO_mg(lsb)   (float)(lsb * 488.0f) / 1000.0f
 
-#define LSM6DSO_FROM_FS_125dps_TO_mdps(lsb)    (float)(lsb * 4375.0f) / 1000.0f
-#define LSM6DSO_FROM_FS_250dps_TO_mdps(lsb)    (float)(lsb *  875.0f) / 1000.0f
-#define LSM6DSO_FROM_FS_500dps_TO_mdps(lsb)    (float)(lsb * 1750.0f) / 1000.0f
-#define LSM6DSO_FROM_FS_1000dps_TO_mdps(lsb)   (float)(lsb *   35.0f) / 1000.0f
-#define LSM6DSO_FROM_FS_2000dps_TO_mdps(lsb)   (float)(lsb *   70.0f) / 1000.0f
+#define LSM6DSO_FROM_FS_125dps_TO_mdps(lsb)    (float)(lsb *  4375.0f) / 1000.0f
+#define LSM6DSO_FROM_FS_250dps_TO_mdps(lsb)    (float)(lsb *  8750.0f) / 1000.0f
+#define LSM6DSO_FROM_FS_500dps_TO_mdps(lsb)    (float)(lsb * 17500.0f) / 1000.0f
+#define LSM6DSO_FROM_FS_1000dps_TO_mdps(lsb)   (float)(lsb * 35000.0f) / 1000.0f
+#define LSM6DSO_FROM_FS_2000dps_TO_mdps(lsb)   (float)(lsb * 70000.0f) / 1000.0f
 
 #define LSM6DSO_FROM_LSB_TO_degC(lsb)    ((float)((int16_t)lsb>>8)*1.0f + 25.0f)
 


### PR DESCRIPTION
Hi Alberto,
I noticed that the values of sensitivity values for gyroscope of LSM6DSO are wrong.
With this PR, they should be correct.
Best Regards,
Carlo