### PR TITLE
Replace 6.5Hz ODR with 1.6Hz ODR for LSM6DSO and LSM6DSOX

### DIFF
--- a/lsm6dso_STdC/driver/lsm6dso_reg.c
+++ b/lsm6dso_STdC/driver/lsm6dso_reg.c
@@ -362,8 +362,8 @@ int32_t lsm6dso_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dso_odr_xl_t *val)
     case LSM6DSO_XL_ODR_6667Hz:
       *val = LSM6DSO_XL_ODR_6667Hz;
       break;
-    case LSM6DSO_XL_ODR_6Hz5:
-      *val = LSM6DSO_XL_ODR_6Hz5;
+    case LSM6DSO_XL_ODR_1Hz6:
+      *val = LSM6DSO_XL_ODR_1Hz6;
       break;
     default:
       *val = LSM6DSO_XL_ODR_OFF;

--- a/lsm6dso_STdC/driver/lsm6dso_reg.h
+++ b/lsm6dso_STdC/driver/lsm6dso_reg.h
@@ -1560,7 +1560,7 @@ typedef enum {
   LSM6DSO_XL_ODR_1667Hz = 8,
   LSM6DSO_XL_ODR_3333Hz = 9,
   LSM6DSO_XL_ODR_6667Hz = 10,
-  LSM6DSO_XL_ODR_6Hz5   = 11, /* (low power only) */
+  LSM6DSO_XL_ODR_1Hz6   = 11, /* (low power only) */
 } lsm6dso_odr_xl_t;
 int32_t lsm6dso_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dso_odr_xl_t val);
 int32_t lsm6dso_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dso_odr_xl_t *val);

--- a/lsm6dsox_STdC/driver/lsm6dsox_reg.c
+++ b/lsm6dsox_STdC/driver/lsm6dsox_reg.c
@@ -433,8 +433,8 @@ int32_t lsm6dsox_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsox_odr_xl_t *val)
     case LSM6DSOX_XL_ODR_6667Hz:
       *val = LSM6DSOX_XL_ODR_6667Hz;
       break;
-    case LSM6DSOX_XL_ODR_6Hz5:
-      *val = LSM6DSOX_XL_ODR_6Hz5;
+    case LSM6DSOX_XL_ODR_1Hz6:
+      *val = LSM6DSOX_XL_ODR_1Hz6;
       break;
     default:
       *val = LSM6DSOX_XL_ODR_OFF;

--- a/lsm6dsox_STdC/driver/lsm6dsox_reg.h
+++ b/lsm6dsox_STdC/driver/lsm6dsox_reg.h
@@ -1739,7 +1739,7 @@ typedef enum {
   LSM6DSOX_XL_ODR_1667Hz = 8,
   LSM6DSOX_XL_ODR_3333Hz = 9,
   LSM6DSOX_XL_ODR_6667Hz = 10,
-  LSM6DSOX_XL_ODR_6Hz5   = 11, /* (low power only) */
+  LSM6DSOX_XL_ODR_1Hz6   = 11, /* (low power only) */
 } lsm6dsox_odr_xl_t;
 int32_t lsm6dsox_xl_data_rate_set(stmdev_ctx_t *ctx, lsm6dsox_odr_xl_t val);
 int32_t lsm6dsox_xl_data_rate_get(stmdev_ctx_t *ctx, lsm6dsox_odr_xl_t *val);


### PR DESCRIPTION
Hi Alberto,
I found this typo in the LSM6DSO and LSM6DSOX PIDs. According the datasheet the low power ODR should be 1.6Hz instead of 6.5Hz.
Best Regards,
Carlo