### PR TITLE
Fix conflict with same type defined in lsm6dso and lsm6dsox

### DIFF
--- a/lsm6dso_STdC/driver/lsm6dso_reg.h
+++ b/lsm6dso_STdC/driver/lsm6dso_reg.h
@@ -2843,8 +2843,8 @@ int32_t lsm6dso_all_sources_get(stmdev_ctx_t *ctx,
 
 typedef struct{
   uint8_t odr_fine_tune;
-} dev_cal_t;
-int32_t lsm6dso_calibration_get(stmdev_ctx_t *ctx, dev_cal_t *val);
+} lsm6dso_dev_cal_t;
+int32_t lsm6dso_calibration_get(stmdev_ctx_t *ctx, lsm6dso_dev_cal_t *val);
 
 typedef struct {
   struct {

--- a/lsm6dsox_STdC/driver/lsm6dsox_reg.h
+++ b/lsm6dsox_STdC/driver/lsm6dsox_reg.h
@@ -3111,8 +3111,8 @@ int32_t lsm6dsox_all_sources_get(stmdev_ctx_t *ctx,
 
 typedef struct{
   uint8_t odr_fine_tune;
-} dev_cal_t;
-int32_t lsm6dsox_calibration_get(stmdev_ctx_t *ctx, dev_cal_t *val);
+} lsm6dsox_dev_cal_t;
+int32_t lsm6dsox_calibration_get(stmdev_ctx_t *ctx, lsm6dsox_dev_cal_t *val);
 
 typedef struct {
   struct {


### PR DESCRIPTION
Hi @albezanc ,
I found a type conflict when lsm6dso and lsm6dsox PIDs are used together. This PR should fix the issue.
Best Regards,
Carlo 