### PR TITLE
lsm9ds1 magnetometer interrupt latch

### DIFF
--- a/lsm9ds1_STdC/driver/lsm9ds1_reg.c
+++ b/lsm9ds1_STdC/driver/lsm9ds1_reg.c
@@ -2774,7 +2774,7 @@ int32_t lsm9ds1_pin_notification_set(stmdev_ctx_t *ctx_mag,
   }
 
   if (ret == 0) {
-    int_cfg_m.iel = (uint8_t)val;
+    int_cfg_m.iel = ! (uint8_t)val;
     ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_INT_CFG_M,
                             (uint8_t *)&int_cfg_m, 1);
   }


### PR DESCRIPTION
According to DocID025715 Rev 3 (page 67), for magnetometer the IEL field in INT_CFG_M register follows this logic:

    0 = Interrupt request Latched
    1 = Interrupt request NOT Latched


**Please, start the title of the pull request with the part number involved** 
*ie: "lsm6dso: ..."*

---

### Device part numbers

Device list of the part numbers impacted by the bug. *(ie lis2mdl, lsm303agr)*

### Checklist

- [ ] improvement
- [ ] bug-fix
- [ ] other

### Description

A clear and concise description.
