### PR TITLE
 lsm9ds1: magnetometer interrupt latch mode fix

### DIFF
--- a/lsm9ds1_STdC/driver/lsm9ds1_reg.c
+++ b/lsm9ds1_STdC/driver/lsm9ds1_reg.c
@@ -2774,7 +2774,7 @@ int32_t lsm9ds1_pin_notification_set(stmdev_ctx_t *ctx_mag,
   }
 
   if (ret == 0) {
-    int_cfg_m.iel = (uint8_t)val;
+    int_cfg_m.iel = ! (uint8_t)val;
     ret = lsm9ds1_write_reg(ctx_mag, LSM9DS1_INT_CFG_M,
                             (uint8_t *)&int_cfg_m, 1);
   }


### PR DESCRIPTION

### Device part numbers

 lsm9ds1 

### Checklist

- [ ] improvement
- [x] bug-fix
- [ ] other

### Description

According to DocID025715 Rev 3 (page 67), for magnetometer the IEL field in INT_CFG_M register follows this logic:

0 = Interrupt request Latched
1 = Interrupt request NOT Latched

but the code in function `lsm9ds1_pin_notification_set` sets it the opposite (XL & G) way.