### PR TITLE
lis2ds12 self test - fix uninitialized array data

### DIFF
--- a/lis2ds12_STdC/examples/lis2ds12_self_test.c
+++ b/lis2ds12_STdC/examples/lis2ds12_self_test.c
@@ -137,11 +137,11 @@ void lis2ds12_self_test(void)
 {
   stmdev_ctx_t dev_ctx_xl;
   uint8_t tx_buffer[1000];
-  int16_t data_raw[3];
-  float maes_st_off[3];
-  float maes_st_on[3];
+  int16_t data_raw[3] = {0};
+  float maes_st_off[3] = {0};
+  float maes_st_on[3] = {0};
   lis2ds12_reg_t reg;
-  float test_val[3];
+  float test_val[3] = {0};
   uint8_t st_result;
   uint8_t i, j;
   /* Initialize mems driver interface */


### PR DESCRIPTION
**Please, start the title of the pull request with the part number involved** 
*ie: "lsm6dso: ..."*

---

### Device part numbers
list2ds12

Device list of the part numbers impacted by the bug. *(ie lis2mdl, lsm303agr)*

### Checklist

- [ ] improvement
- [ x] bug-fix
- [ ] other

### Description

Uninitialized arrays first accessed with += in self_test. 
Leads to outputs such as:
```
maes_st_off[0] = |-15.615999| ; 
maes_st_off[1] = |7725994429986635776.000000| ; 
maes_st_off[2] = |-1005.914368| ; 
``` 
etc. 

With this fix (array initializing) and re-testing, output updates to:
maes_st_off[0] = |-15.323201| ; 
maes_st_off[1] = |-23.472801| ; 
maes_st_off[2] = |-1006.597534| ; 


