### PR TITLE
LSM6DSO32_GY_ODR_OFF does not fit to type of lsm6dso32_xl_data_rate_s…

### DIFF
--- a/lsm6dso32_STdC/examples/lsm6dso32_self_test.c
+++ b/lsm6dso32_STdC/examples/lsm6dso32_self_test.c
@@ -337,7 +337,7 @@ void lsm6dso32_self_test(void)
   /* Disable Self Test */
   lsm6dso32_gy_self_test_set(&dev_ctx, LSM6DSO32_GY_ST_DISABLE);
   /* Disable sensor. */
-  lsm6dso32_xl_data_rate_set(&dev_ctx, LSM6DSO32_GY_ODR_OFF);
+  lsm6dso32_gy_data_rate_set(&dev_ctx, LSM6DSO32_GY_ODR_OFF);
 
   if (st_result == ST_PASS) {
     sprintf((char *)tx_buffer, "Self Test - PASS\r\n" );


### PR DESCRIPTION
…et (#142)


**Please, start the title of the pull request with the part number involved** 
*ie: "lsm6dso: ..."*

---

### Device part numbers

Device list of the part numbers impacted by the bug. *(ie lis2mdl, lsm303agr)*

### Checklist

- [ ] improvement
- [ ] bug-fix
- [ ] other

### Description

A clear and concise description.
