### PR TITLE
Fix incorrect link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In order to run that file, please follow these steps:
 
 More info is available in each specific provided example platform:
 
-- [NUCLEO_F401RE](https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/master/_prj_NucleoF401)
+- [NUCLEO_F401RE](https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/master/_prj_Nucleo_F401RE)
 - [STEVAL_MKI109V3](https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/master/_prj_MKI109V3)
 - [NUCLEO_H503RB](https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/master/_prj_Nucleo_H503RB)
 


### PR DESCRIPTION
**Please, start the title of the pull request with the part number involved** 
*ie: "lsm6dso: ..."*

---

### Device part numbers

Device list of the part numbers impacted by the bug. *(ie lis2mdl, lsm303agr)*

### Checklist

- [ ] improvement
- [ ] bug-fix
- [ ] other

### Description
Fix incorrect link in README.md
