### PR TITLE
Fix typos in LSM6DS3TR-C and LSM6DSL driver

### DIFF
--- a/lsm6ds3tr-c_STdC/examples/lsm6ds3tr_c_read_data_polling.c
+++ b/lsm6ds3tr-c_STdC/examples/lsm6ds3tr_c_read_data_polling.c
@@ -187,7 +187,7 @@ void lsm6ds3tr_c_read_data_polling(void)
     lsm6ds3tr_c_status_reg_get(&dev_ctx, &reg.status_reg);
 
     if (reg.status_reg.xlda) {
-      /* Read magnetic field data */
+      /* Read acceleration field data */
       memset(data_raw_acceleration, 0x00, 3 * sizeof(int16_t));
       lsm6ds3tr_c_acceleration_raw_get(&dev_ctx,
                                        data_raw_acceleration);
@@ -204,7 +204,7 @@ void lsm6ds3tr_c_read_data_polling(void)
     }
 
     if (reg.status_reg.gda) {
-      /* Read magnetic field data */
+      /* Read angular rate field data */
       memset(data_raw_angular_rate, 0x00, 3 * sizeof(int16_t));
       lsm6ds3tr_c_angular_rate_raw_get(&dev_ctx,
                                        data_raw_angular_rate);

--- a/lsm6dsl_STdC/examples/lsm6dsl_read_data_polling.c
+++ b/lsm6dsl_STdC/examples/lsm6dsl_read_data_polling.c
@@ -185,7 +185,7 @@ void lsm6dsl_read_data_polling(void)
     lsm6dsl_status_reg_get(&dev_ctx, &reg.status_reg);
 
     if (reg.status_reg.xlda) {
-      /* Read magnetic field data */
+      /* Read acceleration field data */
       memset(data_raw_acceleration, 0x00, 3 * sizeof(int16_t));
       lsm6dsl_acceleration_raw_get(&dev_ctx, data_raw_acceleration);
       acceleration_mg[0] = lsm6dsl_from_fs2g_to_mg(
@@ -201,7 +201,7 @@ void lsm6dsl_read_data_polling(void)
     }
 
     if (reg.status_reg.gda) {
-      /* Read magnetic field data */
+      /* Read angular rate field data */
       memset(data_raw_angular_rate, 0x00, 3 * sizeof(int16_t));
       lsm6dsl_angular_rate_raw_get(&dev_ctx, data_raw_angular_rate);
       angular_rate_mdps[0] = lsm6dsl_from_fs2000dps_to_mdps(


### PR DESCRIPTION
**Fix typos in LSM6DS3TR-C and LSM6DSL driver** 

---

### Device part numbers

LSM6DS3TR-C, LSM6DSL

### Checklist

- [ ] improvement
- [ ] bug-fix
- [x] other
